### PR TITLE
0.3.5

### DIFF
--- a/lib/evertils/common/authentication.rb
+++ b/lib/evertils/common/authentication.rb
@@ -1,4 +1,4 @@
-require 'singleton'
+require "singleton"
 
 module Evertils
   module Common

--- a/lib/evertils/common/authentication.rb
+++ b/lib/evertils/common/authentication.rb
@@ -138,6 +138,9 @@ module Evertils
           message = "You are rate limited!  Wait #{minutes} minutes"
         end
 
+        message += "\n- "
+        message += e.parameter unless e.parameter.nil?
+
         Notify.warning(message)
         exit(0)
       end

--- a/lib/evertils/common/entity/note.rb
+++ b/lib/evertils/common/entity/note.rb
@@ -56,14 +56,6 @@ module Evertils
         end
 
         #
-        # @since 0.2.0
-        def expunge
-          deprecation_notice('0.2.9', 'Replaced with expunge! to better follow Ruby standards for method names.  Will be removed in 0.3.5')
-
-          @evernote.call(:expungeNote, @entity.guid)
-        end
-
-        #
         # @since 0.2.9
         def move_to(notebook)
           nb = Evertils::Common::Manager::Notebook.instance
@@ -112,22 +104,16 @@ module Evertils
         alias_method :find_by_name, :find
 
         #
+        # https://stackoverflow.com/questions/46694930/evernoteedamnotestorenoteresultspec-is-not-defined
+        # http://www.rubydoc.info/gems/evernote-thrift/Evernote%2FEDAM%2FNoteStore%2FNoteStore%2FClient%3AgetNote
         # @since 0.2.0
         def find_with_contents(name)
-          raise 'ERROR: Evernote API is incomplete, cannot pull full note content'
-
           find_result = find(name)
 
           return if find_result.nil?
 
-          @entity = find_result.entity
-
-          spec = ::Evernote::EDAM::NoteStore::NoteResultSpec.new
-          spec.includeResourcesData = true
-          spec.includeContent = true
-
-          result = @evernote.call(:getNoteWithResultSpec, @entity.guid, spec)
-
+          guid = find_result.entity.guid
+          result = @evernote.call(:getNote, guid, true, false, false, false)
           @entity = result
 
           self if @entity

--- a/lib/evertils/common/manager/notebook.rb
+++ b/lib/evertils/common/manager/notebook.rb
@@ -1,4 +1,4 @@
-require "singleton"
+require 'singleton'
 
 module Evertils
   module Common

--- a/lib/evertils/common/model/note.rb
+++ b/lib/evertils/common/model/note.rb
@@ -84,7 +84,7 @@ module Evertils
         #
         # @since 0.3.3
         def created=(date)
-          date ||= DateTime.now
+          date ||= Date.now
           created_on = (date.to_time.to_i.to_s + "000").to_i
 
           @note.created = created_on

--- a/lib/evertils/common/model/note.rb
+++ b/lib/evertils/common/model/note.rb
@@ -84,7 +84,7 @@ module Evertils
         #
         # @since 0.3.3
         def created=(date)
-          date = DateTime.now unless date
+          date ||= DateTime.now
           created_on = (date.to_time.to_i.to_s + "000").to_i
 
           @note.created = created_on

--- a/lib/evertils/common/version.rb
+++ b/lib/evertils/common/version.rb
@@ -1,5 +1,5 @@
 module Evertils
   module Common
-    VERSION = '0.3.4.1'.freeze
+    VERSION = '0.3.5'.freeze
   end
 end


### PR DESCRIPTION
* Print extra API error message information.
* Remove deprecated method `Entity::Note.expunge`.
* Fix `Entity::Note.find_with_contents` method, it correctly pulls content using the `NoteStore.getNote` method now (instead of trying to work with `NoteResultSpec`).