### PR TITLE
0.3.13

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -287,14 +287,6 @@ Layout/TrailingBlankLines:
 
 # Offense count: 1
 # Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyleForMultiline, SupportedStyles.
-# SupportedStyles: comma, consistent_comma, no_comma
-Style/TrailingCommaInLiteral:
-  Exclude:
-    - 'lib/evertils/common/authentication.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
 Layout/TrailingWhitespace:
   Exclude:
     - 'lib/evertils/common/converter/yaml_to_enml.rb'

--- a/lib/evertils/common/entity/note.rb
+++ b/lib/evertils/common/entity/note.rb
@@ -108,6 +108,30 @@ module Evertils
         alias_method :find_by_name, :find
 
         #
+        # @since 0.3.13
+        def find_with(conf)
+          return unless conf.is_a?(Hash)
+
+          @entity = nil
+
+          filter = ::Evernote::EDAM::NoteStore::NoteFilter.new
+          filter.words = conf
+
+          spec = ::Evernote::EDAM::NoteStore::NotesMetadataResultSpec.new
+          spec.includeTitle = true
+          spec.includeTagGuids = true
+          spec.includeContentLength = true
+          spec.includeCreated = true
+          spec.includeUpdated = true
+
+          result = @evernote.call(:findNotesMetadata, filter, 0, 10, spec)
+
+          @entity = result.notes.detect { |note| note.title == name }
+
+          self if @entity
+        end
+
+        #
         # https://stackoverflow.com/questions/46694930/evernoteedamnotestorenoteresultspec-is-not-defined
         # http://www.rubydoc.info/gems/evernote-thrift/Evernote%2FEDAM%2FNoteStore%2FNoteStore%2FClient%3AgetNote
         # @since 0.2.0

--- a/lib/evertils/common/manager/note.rb
+++ b/lib/evertils/common/manager/note.rb
@@ -23,6 +23,14 @@ module Evertils
         end
 
         #
+        # @since 0.3.13
+        def find_with(conf)
+          entity = Evertils::Common::Entity::Note.new
+          entity.find_with(conf)
+          entity
+        end
+
+        #
         # @since 0.3.0
         def find_with_contents(name)
           entity = Evertils::Common::Entity::Note.new

--- a/lib/evertils/common/query/simple.rb
+++ b/lib/evertils/common/query/simple.rb
@@ -73,6 +73,13 @@ module Evertils
         end
 
         #
+        # @since 0.3.13
+        def find_with(conf)
+          entity = Manager::Note.instance
+          entity.find_with(conf)
+        end
+
+        #
         # @since 0.3.4
         def find_note_contents(name)
           entity = Manager::Note.instance


### PR DESCRIPTION
Allow clients to search using the [EN search grammar](https://dev.evernote.com/doc/articles/search_grammar.php) directly by passing either a hash or a yet-to-be-defined grammar object.